### PR TITLE
make Makefile compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ kirc: kirc.o Makefile
 	$(CC) -o kirc kirc.o $(LDFLAGS)
 
 .c.o:
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
 
 install: all
 	mkdir -p $(DESTDIR)$(BINDIR)

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
-CFLAGS += -std=c99 -Wall -Wextra -pedantic -Wold-style-declaration
-PREFIX ?= /usr
-BINDIR ?= $(PREFIX)/bin
-CC     ?= gcc
+.POSIX:
+
+PREFIX = /usr/local
+BINDIR = $(PREFIX)/bin
 
 all: kirc
 
 kirc: kirc.o Makefile
-	$(CC) $(CFLAGS) -o $@ $@.o $(LDFLAGS)
+	$(CC) -o kirc kirc.o $(LDFLAGS)
 
 .c.o:
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 install: all
-	install -Dm755 kirc $(DESTDIR)$(BINDIR)/kirc
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp -f kirc $(DESTDIR)$(BINDIR)
+	chmod 755 $(DESTDIR)$(BINDIR)/kirc
 
 uninstall:
 	rm -f $(DESTDIR)$(BINDIR)/kirc


### PR DESCRIPTION
Make Makefile compliant to POSIX.1-2017 and to common Makefile standards. (It would be kinda weird if the Makefile of a project, of which being POSIX-compliant was a goal, was not POSIX-compliant itself, no?)

Besides POSIX-compliance, it usually is expected for `${PREFIX}` to be `/usr/local` by default. Some package manager stuff will need to get changed for this.