### PR TITLE
freenode.net instead of .org

### DIFF
--- a/kirc.1
+++ b/kirc.1
@@ -21,7 +21,7 @@ text and color can be controlled with ANSI escape sequences.
 .SH OPTIONS
 .TP
 .BI \-s " server"
-Overrides the default host (irc.freenode.org)
+Overrides the default host (irc.freenode.net)
 .TP
 .BI \-p " port"
 Overrides the default port (6697)

--- a/kirc.c
+++ b/kirc.c
@@ -24,7 +24,7 @@ static char   cdef[MSG_MAX] = "?";       /* default PRIVMSG channel */
 static int    conn;                      /* connection socket */
 static int    verb = 0;                  /* verbose output */
 static int    sasl = 0;                  /* SASL method */
-static char * host = "irc.freenode.org"; /* host address */
+static char * host = "irc.freenode.net"; /* host address */
 static char * port = "6667";             /* port */
 static char * chan = NULL;               /* channel(s) */
 static char * nick = NULL;               /* nickname */


### PR DESCRIPTION
while technically freenode.org works, the correct url for freenode is freenode.net