### PR TITLE
Fix printing of join/part messages when cdef is a substring of the actual channel name

### DIFF
--- a/kirc.c
+++ b/kirc.c
@@ -485,7 +485,7 @@ static void paramPrintNick(struct Param * p) {
 
 static void paramPrintPart(struct Param * p) {
     printf("%*s<-- \x1b[34;1m%s\x1b[0m", p->nicklen - 3, "", p->nickname);
-    if (p->channel != NULL && strstr(p->channel, cdef) == NULL)
+    if (p->channel != NULL && strcmp(p->channel+1, cdef))
         printf(" [\x1b[33m%s\x1b[0m] ", p->channel);
 }
 
@@ -495,7 +495,7 @@ static void paramPrintQuit(struct Param * p) {
 
 static void paramPrintJoin(struct Param * p) {
     printf("%*s--> \x1b[32;1m%s\x1b[0m", p->nicklen - 3, "", p->nickname);
-    if (p->channel != NULL && strstr(p->channel, cdef) == NULL)
+    if (p->channel != NULL && strcmp(p->channel+1, cdef))
         printf(" [\x1b[33m%s\x1b[0m] ", p->channel);
 }
 


### PR DESCRIPTION
This is the exact same problem as #83, just in a different place. I didn't notice this when I found that issue, though.

This time I replaced all instances of `strstr(3)`, so this problem shouldn't appear again.