### PR TITLE
Update docs

### DIFF
--- a/kirc.1
+++ b/kirc.1
@@ -52,6 +52,10 @@ Specifies SASL EXTERNAL mechanism
 .TP
 .BI \-v
 Prints the version information to stderr, then exits
+.TP
+.BI \-V
+Increases verbosity. Causes raw IRC messages to be printed when sent or
+received.
 .SH COMMANDS
 .TP
 .BI /<command>

--- a/kirc.1
+++ b/kirc.1
@@ -32,7 +32,7 @@ Specifies the channel(s) to JOIN (delimited by "," or "|")
 .BI \-n " nick"
 Specifies the NICK connection nickname
 .TP
-.BI \-u " real"
+.BI \-r " real"
 Specifies the users real name
 .TP
 .BI \-u " user"

--- a/kirc.1
+++ b/kirc.1
@@ -65,6 +65,11 @@ Send PRIVMSG to default message channel with <message> as the content
 .TP
 .BI @<channel|nick>
 Send PRIVMSG to specified <channel> or <nick>
+.TP
+.BI @@<channel|nick>
+Send CTCP
+.I ACTION
+PRIVMSG to specified <channel> or <nick>
 .SH AUTHOR
 Michael Czigler <michaelczigler at icloud dot com>
 .SH BUGS

--- a/kirc.1
+++ b/kirc.1
@@ -63,13 +63,21 @@ Set default message channel to <channel>
 .BI <message>
 Send PRIVMSG to default message channel with <message> as the content
 .TP
-.BI @<channel|nick>
-Send PRIVMSG to specified <channel> or <nick>
+.BI @<channel|nick> " <message>"
+Send
+.I <message>
+to specified
+.I <channel>
+or
+.I <nick>
 .TP
 .BI @@<channel|nick>
-Send CTCP
-.I ACTION
-PRIVMSG to specified <channel> or <nick>
+Send CTCP ACTION containing
+.I <message>
+to specified
+.I <channel>
+or
+.I <nick>
 .SH AUTHOR
 Michael Czigler <michaelczigler at icloud dot com>
 .SH BUGS

--- a/kirc.c
+++ b/kirc.c
@@ -674,7 +674,7 @@ static void handleUserInput(struct State * l) {
 
 static void usage(void) {
     fputs("kirc [-s host] [-p port] [-c channel] [-n nick] [-r realname] \
-[-u username] [-k password] [-a token] [-x command] [-o path] [-e|v|V]\n", stderr);
+[-u username] [-k password] [-a token] [-x command] [-o path] [-e] [-v] [-V]\n", stderr);
     exit(2);
 }
 


### PR DESCRIPTION
I noticed that the option `-u` was specified twice in the man page with different meanings. I went through and updated the documentation to reflect the current behavior of kirc.

This includes:
- Fixing the real name option by changing `-u` to `-r` in the man page
- Adding the `@@<target>` command to the man page (for CTCP ACTION messages)
- Adding docs for the `<message>` parameter to the `@<target>` and `@@<target>` commands
- Adding the verbosity option (`-V`) to the man page
- Separating the flag options printed by the `usage()` function (see commit message for rationale)